### PR TITLE
Add both service and claim dates

### DIFF
--- a/edi_835_parser/elements/date_qualifier.py
+++ b/edi_835_parser/elements/date_qualifier.py
@@ -5,9 +5,11 @@ date_qualifiers = {
 	'050': 'received',
 	'150': 'service period start',
 	'151': 'service period end',
+    '405': 'processed',
 	'472': 'service',
 	'232': 'claim statement period start',
 	'233': 'claim statement period end',
+    '573': 'claim denial date',
 }
 
 

--- a/edi_835_parser/loops/claim.py
+++ b/edi_835_parser/loops/claim.py
@@ -76,6 +76,16 @@ class Claim:
             return statement_period_end[0]
 
     @property
+    def claim_received_date(self) -> Optional[DateSegment]:
+        received = [
+            d for d in self.dates if d.qualifier == "received"
+        ]
+        assert len(received) <= 1
+
+        if len(received) == 1:
+            return received[0]
+
+    @property
     def patient(self) -> EntitySegment:
         patient = [e for e in self.entities if e.entity == "patient"]
         assert len(patient) == 1

--- a/edi_835_parser/loops/organization.py
+++ b/edi_835_parser/loops/organization.py
@@ -8,7 +8,6 @@ from edi_835_parser.segments.address import Address as AddressSegment
 from edi_835_parser.segments.location import Location as LocationSegment
 from edi_835_parser.segments.utilities import find_identifier
 
-
 class Organization:
     # TODO: Put claim loop in here to get correct hierarchy
     initiating_identifier = OrganizationSegment.identification

--- a/edi_835_parser/segments/date.py
+++ b/edi_835_parser/segments/date.py
@@ -5,23 +5,23 @@ from edi_835_parser.segments.utilities import split_segment
 
 
 class Date:
-	identification = 'DTM'
+    identification = "DTM"
 
-	identifier = Identifier()
-	date = DateElement()
-	qualifier = DateQualifier()
+    identifier = Identifier()
+    date = DateElement()
+    qualifier = DateQualifier()
 
-	def __init__(self, segment: str):
-		self.segment = segment
-		segment = split_segment(segment)
+    def __init__(self, segment: str):
+        self.segment = segment
+        segment = split_segment(segment)
 
-		self.identifier = segment[0]
-		self.qualifier = segment[1]
-		self.date = segment[2]
+        self.identifier = segment[0]
+        self.qualifier = segment[1]
+        self.date = segment[2]
 
-	def __repr__(self):
-		return '\n'.join(str(item) for item in self.__dict__.items())
+    def __repr__(self):
+        return "\n".join(str(item) for item in self.__dict__.items())
 
 
-if __name__ == '__main__':
-	pass
+if __name__ == "__main__":
+    pass

--- a/edi_835_parser/transaction_set/transaction_set.py
+++ b/edi_835_parser/transaction_set/transaction_set.py
@@ -199,7 +199,7 @@ class TransactionSet:
         claim_end_date = None
         if service.service_period_end:
             end_date = service.service_period_end.date
-        elif claim.claim_statement_period_end:
+        if claim.claim_statement_period_end:
             claim_end_date = claim.claim_statement_period_end.date
 
         ea_code = None

--- a/edi_835_parser/transaction_set/transaction_set.py
+++ b/edi_835_parser/transaction_set/transaction_set.py
@@ -127,14 +127,12 @@ class TransactionSet:
         start_date_type = None
         if claim.claim_statement_period_start:
             start_date = claim.claim_statement_period_start.date
-            start_date_type = "claim_statement"
 
         # if the service doesn't have an end date assume the service and claim dates match
         end_date = None
         end_date_type = None
         if claim.claim_statement_period_end:
             end_date = claim.claim_statement_period_end.date
-            end_date_type = "claim_statement"
 
         ea_code = None
         for reference in claim.references:
@@ -166,10 +164,10 @@ class TransactionSet:
             "allowed_amount": None,
             "paid_amount": claim.claim.paid_amount,
             "payer": organization.payer.name,
-            "start_date": start_date,
-            "end_date": end_date,
-            "start_date_type": start_date_type,
-            "end_date_type": end_date_type,
+            "start_date": None,
+            "end_date": None,
+            "claim_start_date": start_date,
+            "claim_end_date": end_date,
             "rendering_provider": (
                 claim.rendering_provider.name if claim.rendering_provider else None
             ),
@@ -190,23 +188,19 @@ class TransactionSet:
     ) -> dict:
         # if the service doesn't have a start date assume the service and claim dates match
         start_date = None
-        start_date_type = None
+        claim_start_date = None
         if service.service_period_start:
             start_date = service.service_period_start.date
-            start_date_type = "service_period"
-        elif claim.claim_statement_period_start:
-            start_date = claim.claim_statement_period_start.date
-            start_date_type = "claim_statement"
+        if claim.claim_statement_period_start:
+            claim_start_date = claim.claim_statement_period_start.date
 
         # if the service doesn't have an end date assume the service and claim dates match
         end_date = None
-        end_date_type = None
+        claim_end_date = None
         if service.service_period_end:
             end_date = service.service_period_end.date
-            end_date_type = "service_period"
         elif claim.claim_statement_period_end:
-            end_date = claim.claim_statement_period_end.date
-            end_date_type = "claim_statement"
+            claim_end_date = claim.claim_statement_period_end.date
 
         ea_code = None
         for reference in claim.references:
@@ -238,10 +232,10 @@ class TransactionSet:
             "allowed_amount": service.allowed_amount,
             "paid_amount": service.service.paid_amount,
             "payer": organization.payer.name,
-            "start_date": start_date,
-            "end_date": end_date,
-            "start_date_type": start_date_type,
-            "end_date_type": end_date_type,
+            "service_start_date": start_date,
+            "service_end_date": end_date,
+            "claim_start_date": claim_start_date,
+            "claim_end_date": claim_end_date,
             "rendering_provider": (
                 claim.rendering_provider.name if claim.rendering_provider else None
             ),


### PR DESCRIPTION
Currently service and claim dates are handled by the same columns (start_date, end_date, start_date_type, end_date_type).  Since we want both, this PR adds separate columns for claim and service dates.