### PR TITLE
Carc fix

### DIFF
--- a/edi_835_parser/segments/service_adjustment.py
+++ b/edi_835_parser/segments/service_adjustment.py
@@ -4,27 +4,63 @@ from edi_835_parser.elements.adjustment_group_code import AdjustmentGroupCode
 from edi_835_parser.elements.adjustment_reason_code import AdjustmentReasonCode
 from edi_835_parser.segments.utilities import split_segment
 
+class AdjustmentDetail:
+    """Represents a single CARC triplet breakdown."""
+    group_code = AdjustmentGroupCode()
+    reason_code = AdjustmentReasonCode()
+    amount = Dollars()
+
+    def __init__(self, group_code: str, reason_code: str, amount: float):
+        self.group_code = group_code
+        self.reason_code = reason_code
+        self.amount = amount 
+
+    def __repr__(self):
+        return f"ServiceAdjustment(Group: {self.group_code}, CARC: {self.reason_code}, Amount: {self.amount})"
 
 class ServiceAdjustment:
-	identification = 'CAS'
+    identification = "CAS"
 
-	identifier = Identifier()
-	group_code = AdjustmentGroupCode()
-	reason_code = AdjustmentReasonCode()
-	amount = Dollars()
+    identifier = Identifier()
+    def __init__(self, segment: str):
+        self.segment = segment
+        segment = split_segment(segment)
 
-	def __init__(self, segment: str):
-		self.segment = segment
-		segment = split_segment(segment)
+        # get adjustment list
+        self.adjustments = []
 
-		self.identifier = segment[0]
-		self.group_code = segment[1]
-		self.reason_code = segment[2]
-		self.amount = segment[3]
+        # get the identifier (should be 'CAS')
+        self.identifier = segment[0]
 
-	def __repr__(self):
-		return '\n'.join(str(item) for item in self.__dict__.items())
+        # check how many CARC elements
+        n_ele = len(segment)
+
+        for i in range(1, n_ele, 3):
+            # determine appropriate group code
+            if i == 1:
+                base_group_code = segment[i]
+
+            if segment[i] == '':
+                group_code = base_group_code
+            else:
+                group_code = segment[i]
+
+            # get reason code and amount
+            reason_code = segment[i+1]
+            amount = segment[i+2]
+
+            # set AdjustmentDetail
+            carc = AdjustmentDetail(
+                    group_code=group_code,
+                    reason_code=reason_code,
+                    amount=amount,
+                    )
+
+            self.adjustments.append(carc)
+
+    def __repr__(self):
+        return "\n".join(str(item) for item in self.__dict__.items())
 
 
-if __name__ == '__main__':
-	pass
+if __name__ == "__main__":
+    pass

--- a/edi_835_parser/segments/service_adjustment.py
+++ b/edi_835_parser/segments/service_adjustment.py
@@ -31,27 +31,20 @@ class ServiceAdjustment:
 
         # get the identifier (should be 'CAS')
         self.identifier = segment[0]
+        # get the group code
+        base_group_code = segment[1]
 
         # check how many CARC elements
         n_ele = len(segment)
 
-        for i in range(1, n_ele, 3):
-            # determine appropriate group code
-            if i == 1:
-                base_group_code = segment[i]
-
-            if segment[i] == '':
-                group_code = base_group_code
-            else:
-                group_code = segment[i]
-
+        for i in range(2, n_ele, 3):
             # get reason code and amount
-            reason_code = segment[i+1]
-            amount = segment[i+2]
+            reason_code = segment[i]
+            amount = segment[i+1]
 
             # set AdjustmentDetail
             carc = AdjustmentDetail(
-                    group_code=group_code,
+                    group_code=base_group_code,
                     reason_code=reason_code,
                     amount=amount,
                     )

--- a/edi_835_parser/transaction_set/transaction_set.py
+++ b/edi_835_parser/transaction_set/transaction_set.py
@@ -60,10 +60,21 @@ class TransactionSet:
                     )
                     datum["loop"] = "service"
 
-                    for index, adjustment in enumerate(service.adjustments):
-                        datum[f"adj_{index}_group"] = adjustment.group_code.code
-                        datum[f"adj_{index}_code"] = adjustment.reason_code.code
-                        datum[f"adj_{index}_amount"] = adjustment.amount
+                    counter = 0
+                    for adjustment in service.adjustments:
+                        if isinstance(adjustment.adjustments, list):
+                            for individual_adj in adjustment.adjustments:
+                                datum[f"adj_{counter}_group"] = individual_adj.group_code.code
+                                datum[f"adj_{counter}_code"] = individual_adj.reason_code.code
+                                datum[f"adj_{counter}_amount"] = individual_adj.amount
+
+                                counter += 1
+                        else:
+                            datum[f"adj_{counter}_group"] = adjustment.group_code.code
+                            datum[f"adj_{counter}_code"] = adjustment.reason_code.code
+                            datum[f"adj_{counter}_amount"] = adjustment.amount
+                            
+                            counter += 1
 
                     for index, reference in enumerate(service.references):
                         datum[f"ref_{index}_qual"] = reference.qualifier.code
@@ -81,19 +92,25 @@ class TransactionSet:
                     )
                     datum["loop"] = "claim"
 
-                    adjs = list()
                     rems = list()
+                    counter = 0
+                    # get claim CARCs
                     for index, adjustment in enumerate(claim.adjustments):
-                        #TODO: Figure out logic for actually passing in claim codes with amount. Right now just adding the common ones without amounts
-                        adjs.append((adjustment.group_code.code, adjustment.reason_code.code))
-                        #datum[f"adj_{index}_group"] = adjustment.group_code.code
-                        #datum[f"adj_{index}_code"] = adjustment.reason_code.code
-                        #datum[f"adj_{index}_amount"] = adjustment.amount
-                    adjs = list(set(adjs))
-                    for index, adjustment in enumerate(adjs):
-                        datum[f"adj_{index}_group"] = adjustment[0]
-                        datum[f"adj_{index}_code"] = adjustment[1]
+                        if isinstance(adjustment.adjustments, list):
+                            for individual_adj in adjustment.adjustments:
+                                datum[f"adj_{counter}_group"] = individual_adj.group_code.code
+                                datum[f"adj_{counter}_code"] = individual_adj.reason_code.code
+                                datum[f"adj_{counter}_amount"] = individual_adj.amount
 
+                                counter += 1
+                        else:
+                            datum[f"adj_{counter}_group"] = adjustment.group_code.code
+                            datum[f"adj_{counter}_code"] = adjustment.reason_code.code
+                            datum[f"adj_{counter}_amount"] = adjustment.amount
+                            
+                            counter += 1
+
+                    # get claim RARCs
                     for index, remark in enumerate(claim.remarks):
                         rems.append((remark.qualifier.code, remark.code.code))
                     rems = list(set(rems))


### PR DESCRIPTION
The original code only parsed 1 CARC per `CAS` line.  The 835 files we receive from payers can have multiple CARCs per line.  This PR adds the functionality to capture all carcs.